### PR TITLE
(Still needs formal tests -- do not merge in yet) Sanitize Project Information Page under My Projects, Implement App Edit Requests, Vetting Pending for Dead Apps

### DIFF
--- a/app/controllers/appeditrequests_controller.rb
+++ b/app/controllers/appeditrequests_controller.rb
@@ -15,6 +15,25 @@ class AppeditrequestsController < ApplicationController
     @features_updated = @edit_request.features != @app.features
   end
 
+  def update
+    edit_request = AppEditRequest.find(params[:id])
+    app = App.find(edit_request.app_id)
+    unless params[:feedback_given]
+      app.description = edit_request.description
+      app.features = edit_request.features
+      app.save!
+      edit_request.destroy
+      redirect_to appeditrequests_path, alert: "Changes approved for #{app.name}"
+    else
+      new_request = edit_request.dup
+      new_request.feedback = params[:feedback]
+      new_request.status = :reviewed
+      edit_request.destroy
+      new_request.save
+      redirect_to appeditrequests_path, alert: "Feedback submitted for #{app.name}"
+    end
+  end
+
   def auth_user?
     User.find_by_id(session[:user_id])&.coach?
   end

--- a/app/controllers/appeditrequests_controller.rb
+++ b/app/controllers/appeditrequests_controller.rb
@@ -1,4 +1,4 @@
-class AppeditrequestsController < ActionController::Base
+class AppeditrequestsController < ApplicationController
   before_action :auth_user?
 
   def index
@@ -6,6 +6,13 @@ class AppeditrequestsController < ActionController::Base
       format.json { render :json => AppEditRequest.featured }
       format.html
     end
+  end
+
+  def show
+    @edit_request = AppEditRequest.find(params[:id])
+    @app = App.find(@edit_request.app_id)
+    @description_updated = @edit_request.description != @app.description
+    @features_updated = @edit_request.features != @app.features
   end
 
   def auth_user?

--- a/app/controllers/myprojects_controller.rb
+++ b/app/controllers/myprojects_controller.rb
@@ -83,11 +83,15 @@ class MyprojectsController < ApplicationController
     end
 
     def change_button_text(app_id)
+        app = App.find(app_id)
         request = AppEditRequest.where(app_id: app_id)
-        if request.empty?
-            return "Request Change"
-        else
+        if !request.empty?
             return "Update Request"
+        #TODO: enum for app model is not working correctly
+        elsif "#{app.status}" == "dead"
+            return "Request New Feature"
+        else
+            return "Request Change"
         end
     end
 

--- a/app/controllers/myprojects_controller.rb
+++ b/app/controllers/myprojects_controller.rb
@@ -57,8 +57,13 @@ class MyprojectsController < ApplicationController
     end
 
     def update
+        @app = App.find(params[:id])
         @request = AppEditRequest.where(app_id: params[:id])
         if @request.empty?
+            if "#{@app.status}" == "dead"
+                @app.status = 6
+                @app.save!
+            end
             AppEditRequest.create!(:description => params[:description], :features => params[:features], :app_id => params[:id], :requester_id => session[:user_id])
         end
         redirect_to myproject_path(params[:id])

--- a/app/views/appeditrequests/index.html.haml
+++ b/app/views/appeditrequests/index.html.haml
@@ -19,4 +19,4 @@
         %td
           = request.created_at
         %td
-          = link_to "Review", appeditrequests_path(request.id), :class => 'btn btn-primary'
+          = link_to "Review", appeditrequest_path(request.id), :class => 'btn btn-primary'

--- a/app/views/appeditrequests/show.html.haml
+++ b/app/views/appeditrequests/show.html.haml
@@ -36,6 +36,6 @@
           = link_to @app.pivotal_tracker_url, @app.pivotal_tracker_url
   .well#feedback
     %h4 Feedback
-    = text_area_tag :feedback, "", size: "24x6"
+    = text_area_tag :feedback, @edit_request.feedback, size: "24x6"
   = submit_tag 'Approve Change Request', :class => 'btn btn-primary'
-  = submit_tag 'Send Feedback', :class => 'btn btn-primary', name: 'feedback'
+  = submit_tag 'Send Feedback', :class => 'btn btn-primary', name: 'feedback_given'

--- a/app/views/appeditrequests/show.html.haml
+++ b/app/views/appeditrequests/show.html.haml
@@ -1,0 +1,41 @@
+.page-header
+  %h1 Request Change for  App "#{App.find(@app.id).name}"
+
+= form_for @app, :url => appeditrequest_path(@edit_request.id), :method => :put do
+  .well#status
+    %h4 Status: #{@app.status.humanize(capitalize: false)}  
+  .well#description
+    %h4 Current Description
+    = sanitize @app.description
+    - if @description_updated
+      .text-success
+        %h4 Updated Description
+        = sanitize @edit_request.description
+  .well#features
+    %h4 Current App Initial Features
+    = sanitize @app.features
+    - if @features_updated
+      .text-success
+        %h4 updated features
+        = sanitize @edit_request.features
+  .row
+    .col-xs-4.col-sm-4.col-md-4.col-lg-4
+      .well#deployment
+        %h4 Deployment
+        %p{:style => "word-wrap: break-word;"}
+          = link_to @app.deployment_url, @app.deployment_url
+    .col-xs-4.col-sm-4.col-md-4.col-lg-4
+      .well#github
+        %h4 Github
+        %p{:style => "word-wrap: break-word;"}
+          = link_to @app.repository_url, @app.repository_url
+    .col-xs-4.col-sm-4.col-md-4.col-lg-4
+      .well#pivotal
+        %h4 Pivotal Tracker
+        %p{:style => "word-wrap: break-word;"}
+          = link_to @app.pivotal_tracker_url, @app.pivotal_tracker_url
+  .well#feedback
+    %h4 Feedback
+    = text_area_tag :feedback, "", size: "24x6"
+  = submit_tag 'Approve Change Request', :class => 'btn btn-primary'
+  = submit_tag 'Send Feedback', :class => 'btn btn-primary', name: 'feedback'

--- a/app/views/myprojects/show.html.haml
+++ b/app/views/myprojects/show.html.haml
@@ -14,10 +14,10 @@
   %h4 Status: #{@app.status.humanize(capitalize: false)}
 .well#description
   %h4 Description
-  = yield
+  = @app.description
 .well#features
   %h4 App Initial Features
-  = yield
+  = @app.features
 .row
   .col-xs-4.col-sm-4.col-md-4.col-lg-4
     .well#deployment

--- a/app/views/myprojects/show.html.haml
+++ b/app/views/myprojects/show.html.haml
@@ -14,10 +14,10 @@
   %h4 Status: #{@app.status.humanize(capitalize: false)}
 .well#description
   %h4 Description
-  = @app.description
+  = sanitize @app.description
 .well#features
   %h4 App Initial Features
-  = @app.features
+  = sanitize @app.features
 .row
   .col-xs-4.col-sm-4.col-md-4.col-lg-4
     .well#deployment


### PR DESCRIPTION
**TESTING STILL NEEDS TO BE IMPLEMENTED**

Changes:
- Implement logic for handling App Edit Requests for staff (currently deletes and creates new App Edit Requests instead of modifying them)
- App Edit Requests index page works
- App Edit Request vetting page works
- My Project Information page can now show raw HTML from variables (that is sanitized)
- Change-requests made for dead projects now change the project to vetting-pending
- The change-request button for dead projects now shows "Update New Features"
