### PR TITLE
add App Edit Request tests for Index and Show pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   def self.get_edit_req_banner_message(app_edit_request)
     banner_message_by_status = {
         submitted:   'Your app edit request has been submitted to staff for review and approval. Staff has not yet reviewed/approved this request.',
-        reviewed:    'Staff has reviewed and left feedback on you edit request. Kindly review staff feedback and update the request.',
+        reviewed:    'Staff has reviewed and left feedback on your edit request. Kindly review staff feedback and update the request.',
         resubmitted: 'You resubmitted an edit request after staff left feedback but staff has not yet reviewed your updates.'
     }
     banner_message_by_status[app_edit_request&.status&.to_sym] || 'There are currently no edit requests for your app. You can request new edits for you app here.'

--- a/app/views/my_approval_requests/index.html.haml
+++ b/app/views/my_approval_requests/index.html.haml
@@ -34,7 +34,7 @@
             %td
               = link_to req.requester.name, req.requester
             %td
-              = req.created_at.strftime(ApplicationHelper.get_date_format)
+              = req.created_at.strftime("%B %d, %Y  %r")
             %td
               %span.label{class: "label#{ApplicationHelper.get_edit_req_banner_class(@app_edit_request)}"}
                 = req.status

--- a/features/my_approval_requests.feature
+++ b/features/my_approval_requests.feature
@@ -1,0 +1,60 @@
+Feature: staff should be able to approve or comment on requested feature changes or additions made by a user
+  As a logged in Coach user on ESaaS Engagements
+  I should see a tab labeled “App Edit Requests”
+  So that I can approve of or give feedback on requested feature changes or new features on existing apps made by users
+
+  Background: seed data and log in
+    Given the following apps exist:
+      | id  | name  | description | org_id | status      | pivotal_tracker_url | repository_url | deployment_url  | features |
+      | 101 | app1  | test1       | 1      | pending     | p1.com              | repo-url1.com  | deploy-url1.com | f1       |
+      | 102 | app2  | test2       | 1      | pending     | p2.com              | repo-url2.com  | deploy-url2.com | f2       |
+      | 103 | app3  | test3       | 1      | development | p3.com              | repo-url3.com  | deploy-url3.com | f3       |
+      | 104 | app4  | test4       | 4      | pending     | p3.com              | repo-url3.com  | deploy-url3.com | f3       |
+
+    And the following orgs exist:
+      | id | name | contact_id |
+      | 1  | org1 | 2          |
+      | 2  | org2 | 2          |
+      | 3  | org3 | 1          |
+      | 4  | org4 | 2          |
+
+    And the following App Edit Requests exist:
+      | id | description  | features    | feedback | status      | approval_time | app_id | requester_id    | approver_id | created_at                 | updated_at |
+      | 1  | app1         | test1       |          | submitted   |               | 101    | 2               |             | 2019-11-20 7:44:50 -0800   |            |
+      | 2  | app2         | test2       |          | submitted   |               | 102    | 2               |             | 2019-11-20 08:05:50 -0800  |            |
+
+    And the following users exist:
+      | id | name  | github_uid      | email          | user_type     |
+      | 1  | user1 | esaas_developer | test@user.com  | coach         |
+      | 2  | user2 | mock_user1      | test1@user.com | client        |
+      | 3  | user3 |                 | test2@user.com | student       |
+      | 4  | user4 |                 | test4@user.com | client        |
+
+# ---------------------------- Menu bar ----------------------------------------
+Scenario: A user that is not logged in cannot see 'App Edit Requests' tab
+Given I am not logged in
+Then I should not see "App Edit Requests"
+
+Scenario: A logged in user that is not a Coach cannot see 'App Edit Requests' tab
+#  Given I am logged in
+#  Then I should not see "App Edit Requests"
+
+Scenario: A logged in user that is a Coach can see the 'App Edit Requests' tab
+Given I am logged in
+Then I should see "App Edit Requests"
+
+# ------ Previously: App Edit Requests Index -- Currently: MyApprovalRequests Index -------
+
+Scenario: A logged in coach user can see list of App Edit Requests in 'App Edit Requests' tab
+  Given I am logged in
+  When I follow "App Edit Requests"
+  Then I should see "app1" before "app2"
+  And I should not see "app4"
+  And I should not see "app3"
+
+# -------------------- App Edit Request Show Page -----------------------------
+Scenario: A logged in coach user can view an App Edit (Feature Change) Request through the 'App Edit Requests' index
+  Given I am logged in
+  When I follow "App Edit Requests"
+  When I follow the App Edit Request with id 102
+  Then I should see /Edit request for "app2"/

--- a/features/step_definitions/app_edit_request_steps.rb
+++ b/features/step_definitions/app_edit_request_steps.rb
@@ -1,0 +1,10 @@
+Given(/^the following App Edit Requests exist:$/) do |table|
+  # table is a Cucumber::MultilineArgument::DataTable
+  table.hashes.each do |app_edit_request|
+  	AppEditRequest.create(app_edit_request)
+  end
+end
+
+When /^(?:|I )follow the App Edit Request with id (.+)$/ do |id|
+  visit show_my_approval_request_path(app_id: id)
+end

--- a/features/step_definitions/pagination_steps.rb
+++ b/features/step_definitions/pagination_steps.rb
@@ -147,3 +147,9 @@ Then /^I should see (\d+) (.+) starting with (?:.+) (\d+) with sequence format:$
     current_item.keys.each { |k| appears_before(table_element, current_item[k], next_item[k])}
   end
 end
+
+Then /I should see "(.*)" before "(.*)"/ do |e1, e2|
+  #  ensure that that e1 occurs before e2.
+  #  page.body is the entire content of the page as a string.
+  page.body.index(e1).should be < page.body.index(e2)
+end


### PR DESCRIPTION
- Increase code coverage for MyApprovalRequests controller from 28% to 68% (Index and how pages)
- Fix App Edit Request Submission date issue: The date of submission of an edit request is always the same as the first submitted edit request on the App Edit Requests page 
